### PR TITLE
Fixed segfault when creating markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ release/
 debug/
 Images/
 PDFs/
+build/

--- a/AntScope.pro
+++ b/AntScope.pro
@@ -4,6 +4,8 @@
 #
 #-------------------------------------------------
 
+QMAKE_PROJECT_DEPTH = 0
+
 QT       += core gui
 QT       += printsupport
 QT       += serialport

--- a/markers.cpp
+++ b/markers.cpp
@@ -55,8 +55,8 @@ void Markers::setWidgets(QCustomPlot * swr, QCustomPlot * phase, QCustomPlot * r
     m_rsWidget = rs;
     m_rpWidget = rp;
     m_rlWidget = rl;
-    m_tdrWidget = tdr;
     m_s21Widget = s21;
+    m_tdrWidget = tdr;
     m_smithWidget = smith;
 }
 
@@ -100,11 +100,11 @@ void Markers::create(double fq)
     m->rlLine->setPen(QPen(QColor(255,0,0,150)));
     m->rlLineText->setColor(QColor(255, 0, 0, 150));
 
-    m->rlLine = new QCPItemStraightLine(m_s21Widget);
-    m->rlLineText = new QCPItemText(m_s21Widget);
-    m->rlLine->setAntialiased(false);
-    m->rlLine->setPen(QPen(QColor(255,0,0,150)));
-    m->rlLineText->setColor(QColor(255, 0, 0, 150));
+    m->s21Line = new QCPItemStraightLine(m_s21Widget);
+    m->s21LineText = new QCPItemText(m_s21Widget);
+    m->s21Line->setAntialiased(false);
+    m->s21Line->setPen(QPen(QColor(255,0,0,150)));
+    m->s21LineText->setColor(QColor(255, 0, 0, 150));
 
     m_markersList.append(m);
 }
@@ -289,7 +289,7 @@ QList<QList<QVariant>> Markers::updateInfo(QList<int> _columnTypes)
             int pos = name.indexOf('>');
             if (pos != -1)
                 index = name.left(2).toInt();
-            row << QVariant(QVariant::Invalid); // fieldDelete
+            row << QVariant(); // fieldDelete
             row << QVariant(n+1); // fieldMarker
             row << QVariant(index); // fieldSerie
             row << QVariant(fq0); // fieldFQ
@@ -498,7 +498,7 @@ QList<QList<QVariant>> Markers::updateInfo(QList<int> _columnTypes)
                     row << QVariant(dZmod);
                     break;
                 default:
-                    row << QVariant(QVariant::Invalid);
+                    row << QVariant();
                     break;
                 }
             }

--- a/markers.h
+++ b/markers.h
@@ -2,6 +2,7 @@
 #define MARKERS_H
 
 #include <QObject>
+#include <QMetaType>
 #include <qcustomplot.h>
 #include <popup.h>
 #include <markerspopup.h>


### PR DESCRIPTION
When using AntScope2 on Windows and/or Linux, right-clicking on the graph and clicking "Create Marker" results in a memory access violation due to the m_markersList.last()->**s21LineText**->position() field being accessed even though it's value has not been assigned. This is due to an oversight in the **Markers::create** function where the rlLine fields are initialized twice, rather than the s21Line and s21LineText fields. Fixing this was  a simple matter of changing the field names to s21Line and s21LineText to properly initialize those values, and now on my system the program can create markers.

I also fixed some smaller bugs and depreciation warnings.