### PR TITLE
Add Linux AppImage workflow 

### DIFF
--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -16,9 +16,19 @@ permissions:
 
 jobs:
   appimage:
-    name: Build AppImage
-    runs-on: ubuntu-22.04
+    name: Build AppImage (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            fuse_package: libfuse2
+            serial_package: libqt6serialport6-dev
+          - os: ubuntu-24.04
+            fuse_package: libfuse2t64
+            serial_package: qt6-serialport-dev
 
     steps:
       - name: Check out repository
@@ -30,11 +40,12 @@ jobs:
           sudo apt-get install -y \
             build-essential \
             desktop-file-utils \
-            libfuse2 \
+            ${{ matrix.fuse_package }} \
+            libgl-dev \
             libusb-1.0-0-dev \
             patchelf \
             qmake6 \
-            libqt6serialport6-dev \
+            ${{ matrix.serial_package }} \
             qt6-base-dev \
             qt6-base-dev-tools \
             qt6-connectivity-dev \
@@ -98,12 +109,12 @@ jobs:
           test -n "$appimage"
           ref_name="${GITHUB_REF_NAME//\//-}"
           short_sha="${GITHUB_SHA::7}"
-          mv "$appimage" "dist/AntScope2-${ref_name}-${short_sha}-x86_64.AppImage"
+          mv "$appimage" "dist/AntScope2-${{ matrix.os }}-${ref_name}-${short_sha}-x86_64.AppImage"
 
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: AntScope2-AppImage
+          name: AntScope2-AppImage-${{ matrix.os }}
           path: dist/*.AppImage
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -1,0 +1,109 @@
+name: Linux AppImage
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  appimage:
+    name: Build AppImage
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            desktop-file-utils \
+            libfuse2 \
+            libusb-1.0-0-dev \
+            patchelf \
+            qmake6 \
+            qt6-base-dev \
+            qt6-base-dev-tools \
+            qt6-connectivity-dev \
+            qt6-serialport-dev \
+            qt6-tools-dev-tools
+
+      - name: Build release binary
+        run: |
+          qmake6 AntScope.pro CONFIG+=release
+          make -j"$(nproc)"
+
+      - name: Prepare AppDir
+        run: |
+          mkdir -p AppDir/usr/bin
+          mkdir -p AppDir/usr/share/applications
+          mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
+
+          cp build/release/AntScope2 AppDir/usr/bin/AntScope2
+          cp cables.txt AppDir/usr/
+          cp itu-regions.txt AppDir/usr/
+          cp itu-regions-defaults.txt AppDir/usr/
+          cp QtLanguage_ja.qm AppDir/usr/
+          cp QtLanguage_uk.qm AppDir/usr/
+          cp rig_logo.png AppDir/usr/share/icons/hicolor/256x256/apps/antscope2.png
+
+          cat > AppDir/usr/share/applications/antscope2.desktop <<'EOF'
+          [Desktop Entry]
+          Type=Application
+          Name=AntScope2
+          Exec=AntScope2
+          Icon=antscope2
+          Categories=Science;
+          Terminal=false
+          EOF
+
+          desktop-file-validate AppDir/usr/share/applications/antscope2.desktop
+
+      - name: Download linuxdeploy
+        env:
+          LINUXDEPLOY_URL: https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          QT_PLUGIN_URL: https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+        run: |
+          curl -L "$LINUXDEPLOY_URL" -o linuxdeploy-x86_64.AppImage
+          curl -L "$QT_PLUGIN_URL" -o linuxdeploy-plugin-qt-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-qt-x86_64.AppImage
+
+      - name: Build AppImage
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: "1"
+          QMAKE: /usr/bin/qmake6
+        run: |
+          ./linuxdeploy-x86_64.AppImage \
+            --appdir AppDir \
+            --executable AppDir/usr/bin/AntScope2 \
+            --desktop-file AppDir/usr/share/applications/antscope2.desktop \
+            --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/antscope2.png \
+            --plugin qt \
+            --output appimage
+
+          mkdir -p dist
+          appimage="$(find . -maxdepth 1 -type f -name '*.AppImage' ! -name 'linuxdeploy*.AppImage' | head -n 1)"
+          test -n "$appimage"
+          ref_name="${GITHUB_REF_NAME//\//-}"
+          short_sha="${GITHUB_SHA::7}"
+          mv "$appimage" "dist/AntScope2-${ref_name}-${short_sha}-x86_64.AppImage"
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: AntScope2-AppImage
+          path: dist/*.AppImage
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - master
+    tags:
+      - "v*"
   pull_request:
     branches:
       - main
@@ -118,3 +120,34 @@ jobs:
           path: dist/*.AppImage
           if-no-files-found: error
           retention-days: 14
+
+  release:
+    name: Publish release assets
+    needs: appimage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download AppImage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" dist/*.AppImage \
+              --repo "${GITHUB_REPOSITORY}" \
+              --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" dist/*.AppImage \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${GITHUB_REF_NAME}" \
+              --notes "Linux AppImage builds for Ubuntu 22.04 and Ubuntu 24.04."
+          fi

--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           mkdir -p AppDir/usr/bin
           mkdir -p AppDir/usr/share/applications
-          mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
+          mkdir -p AppDir/usr/share/icons/hicolor/64x64/apps
 
           cp build/release/AntScope2 AppDir/usr/bin/AntScope2
           cp cables.txt AppDir/usr/
@@ -68,7 +68,7 @@ jobs:
           cp itu-regions-defaults.txt AppDir/usr/
           cp QtLanguage_ja.qm AppDir/usr/
           cp QtLanguage_uk.qm AppDir/usr/
-          cp rig_logo.png AppDir/usr/share/icons/hicolor/256x256/apps/antscope2.png
+          cp AntScope2.png AppDir/usr/share/icons/hicolor/64x64/apps/antscope2.png
 
           cat > AppDir/usr/share/applications/antscope2.desktop <<'EOF'
           [Desktop Entry]
@@ -100,7 +100,7 @@ jobs:
             --appdir AppDir \
             --executable AppDir/usr/bin/AntScope2 \
             --desktop-file AppDir/usr/share/applications/antscope2.desktop \
-            --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/antscope2.png \
+            --icon-file AppDir/usr/share/icons/hicolor/64x64/apps/antscope2.png \
             --plugin qt \
             --output appimage
 

--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -34,10 +34,10 @@ jobs:
             libusb-1.0-0-dev \
             patchelf \
             qmake6 \
+            libqt6serialport6-dev \
             qt6-base-dev \
             qt6-base-dev-tools \
             qt6-connectivity-dev \
-            qt6-serialport-dev \
             qt6-tools-dev-tools
 
       - name: Build release binary

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ release/
 debug/
 Images/
 PDFs/
+
+# qmake build artifacts
+/.qmake.stash
+/Makefile
+/build/

--- a/AntScope.pro
+++ b/AntScope.pro
@@ -267,6 +267,17 @@ unix:!macx {
     SOURCES += analyzer/usbhid/hidapi/linux/hid.c
     LIBS += -lusb-1.0
     DEFINES += _NO_WINDOWS_
+
+    LINUX_RUNTIME_FILES = \
+        $$PWD/cables.txt \
+        $$PWD/itu-regions.txt \
+        $$PWD/itu-regions-defaults.txt \
+        $$PWD/QtLanguage_ja.qm \
+        $$PWD/QtLanguage_uk.qm
+
+    for(runtime_file, LINUX_RUNTIME_FILES) {
+        QMAKE_POST_LINK += $$QMAKE_COPY $$shell_quote($$runtime_file) $$shell_quote($$DESTDIR/..) $$escape_expand(\\n\\t)
+    }
 }
 
 macx {
@@ -301,4 +312,3 @@ DISTFILES += \
 
 RESOURCES += \
     res.qrc
-

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@ The AntScope2 software is designed to support various models of RigExpert analyz
 
 Windows: QT5, QT Creator 2 and higher
 
-Linux: to do
+Linux: Qt 6 and qmake
+
+Ubuntu 24.04 build dependencies:
+
+```sh
+sudo apt-get install qmake6 qt6-base-dev qt6-base-dev-tools qt6-connectivity-dev qt6-serialport-dev qt6-tools-dev-tools libusb-1.0-0-dev build-essential
+```
+
+Build:
+
+```sh
+qmake6 AntScope.pro CONFIG+=release
+make -j$(nproc)
+```
+
+The Linux binary is created at `build/release/AntScope2`. The qmake post-link step copies the required runtime data files to `build/`, where the application expects them for local builds.
 
 Mac OS: to do


### PR DESCRIPTION
 ## Summary

  - Add a GitHub Actions workflow for building Linux AppImage artifacts.
  - Build and upload separate AppImages for Ubuntu 22.04 and Ubuntu 24.04.
  - Install distro-specific Qt/FUSE packages and OpenGL headers required by the qmake build.
  - Use a valid square application icon for linuxdeploy packaging.

  ## Verification

  - GitHub Actions run succeeded for both matrix jobs: `ubuntu-22.04` and `ubuntu-24.04`.
  - Artifacts were uploaded for both AppImage builds.

  Workflow run: https://github.com/shaposhnikoff/AntScope2/actions/runs/28279334834
